### PR TITLE
Support the `LanguageBCP47` element

### DIFF
--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -60,6 +60,7 @@ pub enum ElementId {
     DefaultDuration,
     Name,
     Language,
+    LanguageBcp47,
     CodecId,
     CodecPrivate,
     CodecName,
@@ -212,6 +213,7 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::DefaultDuration, ElementType::Unsigned);
         m.insert(ElementId::Name, ElementType::String);
         m.insert(ElementId::Language, ElementType::String);
+        m.insert(ElementId::LanguageBcp47, ElementType::String);
         m.insert(ElementId::CodecId, ElementType::String);
         m.insert(ElementId::CodecPrivate, ElementType::Binary);
         m.insert(ElementId::CodecName, ElementType::String);
@@ -366,6 +368,7 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x23E383, ElementId::DefaultDuration);
         m.insert(0x536E, ElementId::Name);
         m.insert(0x22B59C, ElementId::Language);
+        m.insert(0x22B59D, ElementId::LanguageBcp47);
         m.insert(0x86, ElementId::CodecId);
         m.insert(0x63A2, ElementId::CodecPrivate);
         m.insert(0x258688, ElementId::CodecName);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,6 +292,7 @@ pub struct TrackEntry {
     default_duration: Option<NonZeroU64>,
     name: Option<String>,
     language: Option<String>,
+    language_bcp47: Option<String>,
     codec_id: String,
     codec_private: Option<Vec<u8>>,
     codec_name: Option<String>,
@@ -320,6 +321,7 @@ impl<R: Read + Seek> ParsableElement<R> for TrackEntry {
         let default_duration = try_find_nonzero(fields, ElementId::DefaultDuration)?;
         let name = try_find_string(fields, ElementId::Name)?;
         let language = try_find_string(fields, ElementId::Language)?;
+        let language_bcp47 = try_find_string(fields, ElementId::LanguageBcp47)?;
         let codec_id = find_string(fields, ElementId::CodecId)?;
         let codec_private = try_find_binary(r, fields, ElementId::CodecPrivate)?;
         let codec_name = try_find_string(fields, ElementId::CodecName)?;
@@ -351,6 +353,7 @@ impl<R: Read + Seek> ParsableElement<R> for TrackEntry {
             default_duration,
             name,
             language,
+            language_bcp47,
             codec_id,
             codec_private,
             codec_name,
@@ -437,8 +440,24 @@ impl TrackEntry {
     }
 
     /// Specifies the language of the track.
+    ///
+    /// Can be either the 3 letters bibliographic ISO-639-2 form (like `fre` for french), or such a
+    /// language code followed by a dash and a country code for specialities in languages
+    /// (like `fre-ca` for Canadian French).
     pub fn language(&self) -> Option<&str> {
         match self.language.as_ref() {
+            None => None,
+            Some(language) => Some(language),
+        }
+    }
+
+    /// Specifies the language of the track as IETF language tag.
+    ///
+    /// Starting with Matroska 4 the BCF47 language code is recommended instead of the regular
+    /// language element used in Matroska 1-3. If a BCF47 language element is present the regular
+    /// language element must be ignored.
+    pub fn language_bcp47(&self) -> Option<&str> {
+        match self.language_bcp47.as_ref() {
             None => None,
             Some(language) => Some(language),
         }


### PR DESCRIPTION
The specification says the `LanguageBCP47` element is the new way to specify a tracks language in Matroska 4. If it is present it overrides the regular `Language` element.