### PR TITLE
Support all elements related to ordered chapters

### DIFF
--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -370,6 +370,15 @@ pub(crate) fn try_find_string(
     }
 }
 
+/// Expects to find an element with the Element ID for a string inside a list of children.
+pub(crate) fn find_binary<R: Read + Seek>(
+    r: &mut R,
+    fields: &[(ElementId, ElementData)],
+    element_id: ElementId,
+) -> Result<Vec<u8>> {
+    try_find_binary(r, fields, element_id)?.ok_or(DemuxError::ElementNotFound(element_id))
+}
+
 /// Tries to find an element with the Element ID for binary inside a list of children.
 pub(crate) fn try_find_binary<R: Read + Seek>(
     r: &mut R,

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -3,7 +3,7 @@
 use std::{
     convert::{TryFrom, TryInto},
     io::{Read, Seek, SeekFrom},
-    num::NonZeroU64,
+    num::{NonZeroU128, NonZeroU64},
 };
 
 use crate::element_id::{element_id_to_type, id_to_element_id};
@@ -392,6 +392,32 @@ pub(crate) fn try_find_binary<R: Read + Seek>(
             r.seek(SeekFrom::Start(*offset))?;
             r.read_exact(&mut data)?;
             Ok(Some(data))
+        } else {
+            Err(DemuxError::UnexpectedDataType)
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// Tries to find an element with the Element ID for an UUID inside a list of children.
+pub(crate) fn try_find_uuid<R: Read + Seek>(
+    r: &mut R,
+    fields: &[(ElementId, ElementData)],
+    element_id: ElementId,
+) -> Result<Option<NonZeroU128>> {
+    if let Some((_, data)) = fields.iter().find(|(id, _)| *id == element_id) {
+        if let ElementData::Location { offset, size } = data {
+            if *size != 16 {
+                return Err(DemuxError::UnexpectedDataType);
+            }
+            let mut bytes = [0u8; 16];
+            r.seek(SeekFrom::Start(*offset))?;
+            r.read_exact(&mut bytes)?;
+            let uuid = u128::from_be_bytes(bytes);
+            NonZeroU128::new(uuid)
+                .map(Some)
+                .ok_or(DemuxError::NonZeroValueIsZero(element_id))
         } else {
             Err(DemuxError::UnexpectedDataType)
         }

--- a/src/ebml.rs
+++ b/src/ebml.rs
@@ -213,6 +213,24 @@ pub(crate) fn try_find_unsigned(
     }
 }
 
+/// Tries to find all element with the Element ID for an unsigned integer inside a list of children.
+pub(crate) fn find_all_unsigned(
+    fields: &[(ElementId, ElementData)],
+    element_id: ElementId,
+) -> Result<Vec<u64>> {
+    fields
+        .iter()
+        .filter(|(id, _)| *id == element_id)
+        .map(|(_, data)| {
+            if let ElementData::Unsigned(value) = data {
+                Ok(*value)
+            } else {
+                Err(DemuxError::UnexpectedDataType)
+            }
+        })
+        .collect()
+}
+
 /// Tries to find an element with the Element ID for a custom type inside a list of children, otherwise sets the default value.
 pub(crate) fn try_find_custom_type_or<T: From<u64>>(
     fields: &[(ElementId, ElementData)],

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -149,6 +149,7 @@ pub enum ElementId {
     ChapterFlagHidden,
     ChapterFlagEnabled,
     ChapterSkipType,
+    ChapterPhysicalEquiv,
     ChapterTrack,
     ChapterTrackUID,
     ChapterDisplay,
@@ -323,6 +324,7 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapterFlagHidden, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagEnabled, ElementType::Unsigned);
         m.insert(ElementId::ChapterSkipType, ElementType::Unsigned);
+        m.insert(ElementId::ChapterPhysicalEquiv, ElementType::Unsigned);
         m.insert(ElementId::ChapterTrack, ElementType::Master);
         m.insert(ElementId::ChapterTrackUID, ElementType::Unsigned);
         m.insert(ElementId::ChapterDisplay, ElementType::Master);
@@ -499,6 +501,7 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x98, ElementId::ChapterFlagHidden);
         m.insert(0x4598, ElementId::ChapterFlagEnabled);
         m.insert(0x4588, ElementId::ChapterSkipType);
+        m.insert(0x63C3, ElementId::ChapterPhysicalEquiv);
         m.insert(0x8F, ElementId::ChapterTrack);
         m.insert(0x89, ElementId::ChapterTrackUID);
         m.insert(0x80, ElementId::ChapterDisplay);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -184,6 +184,7 @@ pub enum ElementId {
     SimpleTag,
     TagName,
     TagLanguage,
+    TagLanguageBcp47,
     TagDefault,
     TagString,
     TagBinary,
@@ -371,6 +372,7 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::SimpleTag, ElementType::Master);
         m.insert(ElementId::TagName, ElementType::String);
         m.insert(ElementId::TagLanguage, ElementType::String);
+        m.insert(ElementId::TagLanguageBcp47, ElementType::String);
         m.insert(ElementId::TagDefault, ElementType::Unsigned);
         m.insert(ElementId::TagString, ElementType::String);
         m.insert(ElementId::TagBinary, ElementType::Binary);
@@ -560,6 +562,7 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x67C8, ElementId::SimpleTag);
         m.insert(0x45A3, ElementId::TagName);
         m.insert(0x447A, ElementId::TagLanguage);
+        m.insert(0x447B, ElementId::TagLanguageBcp47);
         m.insert(0x4484, ElementId::TagDefault);
         m.insert(0x4487, ElementId::TagString);
         m.insert(0x4485, ElementId::TagBinary);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -134,6 +134,13 @@ pub enum ElementId {
     CueBlockNumber,
     Chapters,
     EditionEntry,
+    EditionUid,
+    EditionFlagHidden,
+    EditionFlagDefault,
+    EditionFlagOrdered,
+    EditionDisplay,
+    EditionString,
+    EditionLanguageIetf,
     ChapterAtom,
     ChapterUid,
     ChapterStringUid,
@@ -290,6 +297,13 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::CueBlockNumber, ElementType::Unsigned);
         m.insert(ElementId::Chapters, ElementType::Master);
         m.insert(ElementId::EditionEntry, ElementType::Master);
+        m.insert(ElementId::EditionUid, ElementType::Unsigned);
+        m.insert(ElementId::EditionFlagHidden, ElementType::Unsigned);
+        m.insert(ElementId::EditionFlagDefault, ElementType::Unsigned);
+        m.insert(ElementId::EditionFlagOrdered, ElementType::Unsigned);
+        m.insert(ElementId::EditionString, ElementType::String);
+        m.insert(ElementId::EditionLanguageIetf, ElementType::String);
+        m.insert(ElementId::EditionDisplay, ElementType::Master);
         m.insert(ElementId::ChapterAtom, ElementType::Master);
         m.insert(ElementId::ChapterUid, ElementType::Unsigned);
         m.insert(ElementId::ChapterStringUid, ElementType::String);
@@ -448,6 +462,13 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x5378, ElementId::CueBlockNumber);
         m.insert(0x1043A770, ElementId::Chapters);
         m.insert(0x45B9, ElementId::EditionEntry);
+        m.insert(0x45BC, ElementId::EditionUid);
+        m.insert(0x45BD, ElementId::EditionFlagHidden);
+        m.insert(0x45DB, ElementId::EditionFlagDefault);
+        m.insert(0x45DD, ElementId::EditionFlagOrdered);
+        m.insert(0x4520, ElementId::EditionDisplay);
+        m.insert(0x4521, ElementId::EditionString);
+        m.insert(0x45E4, ElementId::EditionLanguageIetf);
         m.insert(0xB6, ElementId::ChapterAtom);
         m.insert(0x73C4, ElementId::ChapterUid);
         m.insert(0x5654, ElementId::ChapterStringUid);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -146,6 +146,8 @@ pub enum ElementId {
     ChapterStringUid,
     ChapterTimeStart,
     ChapterTimeEnd,
+    ChapterFlagHidden,
+    ChapterFlagEnabled,
     ChapterDisplay,
     ChapString,
     ChapLanguage,
@@ -309,6 +311,8 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapterStringUid, ElementType::String);
         m.insert(ElementId::ChapterTimeStart, ElementType::Unsigned);
         m.insert(ElementId::ChapterTimeEnd, ElementType::Unsigned);
+        m.insert(ElementId::ChapterFlagHidden, ElementType::Unsigned);
+        m.insert(ElementId::ChapterFlagEnabled, ElementType::Unsigned);
         m.insert(ElementId::ChapterDisplay, ElementType::Master);
         m.insert(ElementId::ChapString, ElementType::String);
         m.insert(ElementId::ChapLanguage, ElementType::String);
@@ -474,6 +478,8 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x5654, ElementId::ChapterStringUid);
         m.insert(0x91, ElementId::ChapterTimeStart);
         m.insert(0x92, ElementId::ChapterTimeEnd);
+        m.insert(0x98, ElementId::ChapterFlagHidden);
+        m.insert(0x4598, ElementId::ChapterFlagEnabled);
         m.insert(0x80, ElementId::ChapterDisplay);
         m.insert(0x85, ElementId::ChapString);
         m.insert(0x437C, ElementId::ChapLanguage);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -148,7 +148,9 @@ pub enum ElementId {
     ChapterTimeEnd,
     ChapterFlagHidden,
     ChapterFlagEnabled,
+    ChapterSegmentUuid,
     ChapterSkipType,
+    ChapterSegmentEditionUid,
     ChapterPhysicalEquiv,
     ChapterTrack,
     ChapterTrackUID,
@@ -323,7 +325,9 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapterTimeEnd, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagHidden, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagEnabled, ElementType::Unsigned);
+        m.insert(ElementId::ChapterSegmentUuid, ElementType::Binary);
         m.insert(ElementId::ChapterSkipType, ElementType::Unsigned);
+        m.insert(ElementId::ChapterSegmentEditionUid, ElementType::Unsigned);
         m.insert(ElementId::ChapterPhysicalEquiv, ElementType::Unsigned);
         m.insert(ElementId::ChapterTrack, ElementType::Master);
         m.insert(ElementId::ChapterTrackUID, ElementType::Unsigned);
@@ -500,7 +504,9 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x92, ElementId::ChapterTimeEnd);
         m.insert(0x98, ElementId::ChapterFlagHidden);
         m.insert(0x4598, ElementId::ChapterFlagEnabled);
+        m.insert(0x6E67, ElementId::ChapterSegmentUuid);
         m.insert(0x4588, ElementId::ChapterSkipType);
+        m.insert(0x6EBC, ElementId::ChapterSegmentEditionUid);
         m.insert(0x63C3, ElementId::ChapterPhysicalEquiv);
         m.insert(0x8F, ElementId::ChapterTrack);
         m.insert(0x89, ElementId::ChapterTrackUID);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -148,6 +148,7 @@ pub enum ElementId {
     ChapterTimeEnd,
     ChapterFlagHidden,
     ChapterFlagEnabled,
+    ChapterSkipType,
     ChapterTrack,
     ChapterTrackUID,
     ChapterDisplay,
@@ -321,6 +322,7 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapterTimeEnd, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagHidden, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagEnabled, ElementType::Unsigned);
+        m.insert(ElementId::ChapterSkipType, ElementType::Unsigned);
         m.insert(ElementId::ChapterTrack, ElementType::Master);
         m.insert(ElementId::ChapterTrackUID, ElementType::Unsigned);
         m.insert(ElementId::ChapterDisplay, ElementType::Master);
@@ -496,6 +498,7 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x92, ElementId::ChapterTimeEnd);
         m.insert(0x98, ElementId::ChapterFlagHidden);
         m.insert(0x4598, ElementId::ChapterFlagEnabled);
+        m.insert(0x4588, ElementId::ChapterSkipType);
         m.insert(0x8F, ElementId::ChapterTrack);
         m.insert(0x89, ElementId::ChapterTrackUID);
         m.insert(0x80, ElementId::ChapterDisplay);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -155,6 +155,12 @@ pub enum ElementId {
     ChapLanguage,
     ChapLanguageIetf,
     ChapCountry,
+    ChapProcess,
+    ChapProcessCodecId,
+    ChapProcessPrivate,
+    ChapProcessCommand,
+    ChapProcessTime,
+    ChapProcessData,
     Tags,
     Tag,
     Targets,
@@ -322,6 +328,12 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapLanguage, ElementType::String);
         m.insert(ElementId::ChapLanguageIetf, ElementType::String);
         m.insert(ElementId::ChapCountry, ElementType::String);
+        m.insert(ElementId::ChapProcess, ElementType::Master);
+        m.insert(ElementId::ChapProcessCodecId, ElementType::Unsigned);
+        m.insert(ElementId::ChapProcessPrivate, ElementType::Binary);
+        m.insert(ElementId::ChapProcessCommand, ElementType::Master);
+        m.insert(ElementId::ChapProcessTime, ElementType::Unsigned);
+        m.insert(ElementId::ChapProcessData, ElementType::Binary);
         m.insert(ElementId::Tags, ElementType::Master);
         m.insert(ElementId::Tag, ElementType::Master);
         m.insert(ElementId::Targets, ElementType::Master);
@@ -491,6 +503,12 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x437C, ElementId::ChapLanguage);
         m.insert(0x437D, ElementId::ChapLanguageIetf);
         m.insert(0x437E, ElementId::ChapCountry);
+        m.insert(0x6944, ElementId::ChapProcess);
+        m.insert(0x6955, ElementId::ChapProcessCodecId);
+        m.insert(0x450D, ElementId::ChapProcessPrivate);
+        m.insert(0x6911, ElementId::ChapProcessCommand);
+        m.insert(0x6922, ElementId::ChapProcessTime);
+        m.insert(0x6933, ElementId::ChapProcessData);
         m.insert(0x1254C367, ElementId::Tags);
         m.insert(0x7373, ElementId::Tag);
         m.insert(0x63C0, ElementId::Targets);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -24,6 +24,13 @@ pub enum ElementId {
     SeekId,
     SeekPosition,
     Info,
+    SegmentUuid,
+    SegmentFilename,
+    PrevUuid,
+    PrevFilename,
+    NextUuid,
+    NextFilename,
+    SegmentFamily,
     TimestampScale,
     Duration,
     DateUtc,
@@ -201,6 +208,13 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::SeekId, ElementType::Unsigned);
         m.insert(ElementId::SeekPosition, ElementType::Unsigned);
         m.insert(ElementId::Info, ElementType::Master);
+        m.insert(ElementId::SegmentUuid, ElementType::Binary);
+        m.insert(ElementId::SegmentFilename, ElementType::String);
+        m.insert(ElementId::PrevUuid, ElementType::Binary);
+        m.insert(ElementId::PrevFilename, ElementType::String);
+        m.insert(ElementId::NextUuid, ElementType::Binary);
+        m.insert(ElementId::NextFilename, ElementType::String);
+        m.insert(ElementId::SegmentFamily, ElementType::Binary);
         m.insert(ElementId::TimestampScale, ElementType::Unsigned);
         m.insert(ElementId::Duration, ElementType::Float);
         m.insert(ElementId::DateUtc, ElementType::Date);
@@ -380,6 +394,13 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x53AB, ElementId::SeekId);
         m.insert(0x53AC, ElementId::SeekPosition);
         m.insert(0x1549A966, ElementId::Info);
+        m.insert(0x73A4, ElementId::SegmentUuid);
+        m.insert(0x7384, ElementId::SegmentFilename);
+        m.insert(0x3CB923, ElementId::PrevUuid);
+        m.insert(0x3C83AB, ElementId::PrevFilename);
+        m.insert(0x3EB923, ElementId::NextUuid);
+        m.insert(0x3E83BB, ElementId::NextFilename);
+        m.insert(0x4444, ElementId::SegmentFamily);
         m.insert(0x2AD7B1, ElementId::TimestampScale);
         m.insert(0x4489, ElementId::Duration);
         m.insert(0x4461, ElementId::DateUtc);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -148,6 +148,8 @@ pub enum ElementId {
     ChapterTimeEnd,
     ChapterFlagHidden,
     ChapterFlagEnabled,
+    ChapterTrack,
+    ChapterTrackUID,
     ChapterDisplay,
     ChapString,
     ChapLanguage,
@@ -313,6 +315,8 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::ChapterTimeEnd, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagHidden, ElementType::Unsigned);
         m.insert(ElementId::ChapterFlagEnabled, ElementType::Unsigned);
+        m.insert(ElementId::ChapterTrack, ElementType::Master);
+        m.insert(ElementId::ChapterTrackUID, ElementType::Unsigned);
         m.insert(ElementId::ChapterDisplay, ElementType::Master);
         m.insert(ElementId::ChapString, ElementType::String);
         m.insert(ElementId::ChapLanguage, ElementType::String);
@@ -480,6 +484,8 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x92, ElementId::ChapterTimeEnd);
         m.insert(0x98, ElementId::ChapterFlagHidden);
         m.insert(0x4598, ElementId::ChapterFlagEnabled);
+        m.insert(0x8F, ElementId::ChapterTrack);
+        m.insert(0x89, ElementId::ChapterTrackUID);
         m.insert(0x80, ElementId::ChapterDisplay);
         m.insert(0x85, ElementId::ChapString);
         m.insert(0x437C, ElementId::ChapLanguage);

--- a/src/element_id.rs
+++ b/src/element_id.rs
@@ -178,6 +178,9 @@ pub enum ElementId {
     TargetTypeValue,
     TargetType,
     TagTrackUid,
+    TagEditionUid,
+    TagChapterUid,
+    TagAttachmentUid,
     SimpleTag,
     TagName,
     TagLanguage,
@@ -362,6 +365,9 @@ pub(crate) fn element_id_to_type(id: ElementId) -> ElementType {
         m.insert(ElementId::TargetTypeValue, ElementType::Unsigned);
         m.insert(ElementId::TargetType, ElementType::String);
         m.insert(ElementId::TagTrackUid, ElementType::Unsigned);
+        m.insert(ElementId::TagEditionUid, ElementType::Unsigned);
+        m.insert(ElementId::TagChapterUid, ElementType::Unsigned);
+        m.insert(ElementId::TagAttachmentUid, ElementType::Unsigned);
         m.insert(ElementId::SimpleTag, ElementType::Master);
         m.insert(ElementId::TagName, ElementType::String);
         m.insert(ElementId::TagLanguage, ElementType::String);
@@ -548,6 +554,9 @@ pub(crate) fn id_to_element_id(id: u32) -> ElementId {
         m.insert(0x68CA, ElementId::TargetTypeValue);
         m.insert(0x63CA, ElementId::TargetType);
         m.insert(0x63C5, ElementId::TagTrackUid);
+        m.insert(0x63C9, ElementId::TagEditionUid);
+        m.insert(0x63C4, ElementId::TagChapterUid);
+        m.insert(0x63C6, ElementId::TagAttachmentUid);
         m.insert(0x67C8, ElementId::SimpleTag);
         m.insert(0x45A3, ElementId::TagName);
         m.insert(0x447A, ElementId::TagLanguage);

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -590,6 +590,48 @@ impl From<u64> for ChapterSkipType {
     }
 }
 
+/// Specify the physical equivalent of this ChapterAtom.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChapterPhysicalEquiv {
+    /// Unknown.
+    Unknown,
+    /// The collection of different media.
+    ///
+    /// Example: set / package.
+    Set,
+    /// The physical medium.
+    ///
+    /// Example: CD / 12” / TAPE / DVD / VHS / LASERDISC.
+    Medium,
+    /// Side, when the original medium has different sides.
+    Side,
+    /// Layer.
+    ///
+    /// Physical layers on DVDs.
+    Layer,
+    /// Session, as found on CDs and DVDs.
+    Session,
+    /// Trask, as found on CDs and DVDs..
+    Track,
+    /// Index, as found on CDs and DVDs..
+    Index,
+}
+
+impl From<u64> for ChapterPhysicalEquiv {
+    fn from(d: u64) -> Self {
+        match d {
+            70 => ChapterPhysicalEquiv::Set,
+            60 => ChapterPhysicalEquiv::Medium,
+            50 => ChapterPhysicalEquiv::Side,
+            40 => ChapterPhysicalEquiv::Layer,
+            30 => ChapterPhysicalEquiv::Session,
+            20 => ChapterPhysicalEquiv::Track,
+            10 => ChapterPhysicalEquiv::Index,
+            _ => ChapterPhysicalEquiv::Unknown,
+        }
+    }
+}
+
 /// The type of the codec used for the chapter menu processing.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -554,6 +554,42 @@ impl From<u64> for AesSettingsCipherMode {
     }
 }
 
+/// Indicate what type of content the ChapterAtom contains and might be skipped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChapterSkipType {
+    /// Unknown.
+    Unknown,
+    /// No skipping.
+    NoSkipping,
+    /// Opening Credits.
+    OpeningCredits,
+    /// End Credits.
+    EndCredits,
+    /// Recap.
+    Recap,
+    /// Next Preview.
+    NextPreview,
+    /// Preview.
+    Preview,
+    /// Advertisement.
+    Advertisement,
+}
+
+impl From<u64> for ChapterSkipType {
+    fn from(d: u64) -> Self {
+        match d {
+            0 => ChapterSkipType::NoSkipping,
+            1 => ChapterSkipType::OpeningCredits,
+            2 => ChapterSkipType::EndCredits,
+            3 => ChapterSkipType::Recap,
+            4 => ChapterSkipType::NextPreview,
+            5 => ChapterSkipType::Preview,
+            6 => ChapterSkipType::Advertisement,
+            _ => ChapterSkipType::Unknown,
+        }
+    }
+}
+
 /// The type of the codec used for the chapter menu processing.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -553,3 +553,49 @@ impl From<u64> for AesSettingsCipherMode {
         }
     }
 }
+
+/// The type of the codec used for the chapter menu processing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ChapProcessCodecId {
+    /// Unknown.
+    Unknown,
+    /// Native matroska processing.
+    Matroska,
+    /// DVD command set.
+    DvdMenu,
+}
+
+impl From<u64> for ChapProcessCodecId {
+    fn from(d: u64) -> Self {
+        match d {
+            0 => ChapProcessCodecId::Matroska,
+            1 => ChapProcessCodecId::DvdMenu,
+            _ => ChapProcessCodecId::Unknown,
+        }
+    }
+}
+
+/// Defines when the process command should be handled.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChapProcessTime {
+    /// Unknown.
+    Unknown,
+    /// Process during the whole chapter.
+    WholeChapter,
+    /// Process before starting playback.
+    BeforePlayback,
+    /// Process after starting playback.
+    AfterPlayback,
+}
+
+impl From<u64> for ChapProcessTime {
+    fn from(d: u64) -> Self {
+        match d {
+            0 => ChapProcessTime::WholeChapter,
+            1 => ChapProcessTime::BeforePlayback,
+            2 => ChapProcessTime::AfterPlayback,
+            _ => ChapProcessTime::Unknown,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,18 +211,33 @@ pub struct Info {
     title: Option<String>,
     muxing_app: String,
     writing_app: String,
+    segment_uuid: Option<NonZeroU128>,
+    segment_filename: Option<String>,
+    prev_uuid: Option<NonZeroU128>,
+    prev_filename: Option<String>,
+    next_uuid: Option<NonZeroU128>,
+    next_filename: Option<String>,
+    segment_family: Option<NonZeroU128>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for Info {
     type Output = Self;
 
-    fn new(_r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
+    fn new(r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
         let timestamp_scale = find_nonzero_or(fields, ElementId::TimestampScale, 1000000)?;
         let duration = try_find_float(fields, ElementId::Duration)?;
         let date_utc = try_find_date(fields, ElementId::DateUtc)?;
         let title = try_find_string(fields, ElementId::Title)?;
         let muxing_app = find_string(fields, ElementId::MuxingApp)?;
         let writing_app = find_string(fields, ElementId::WritingApp)?;
+
+        let segment_uuid = try_find_uuid(r, fields, ElementId::SegmentUuid)?;
+        let segment_filename = try_find_string(fields, ElementId::SegmentFilename)?;
+        let prev_uuid = try_find_uuid(r, fields, ElementId::PrevUuid)?;
+        let prev_filename = try_find_string(fields, ElementId::PrevFilename)?;
+        let next_uuid = try_find_uuid(r, fields, ElementId::NextUuid)?;
+        let next_filename = try_find_string(fields, ElementId::NextFilename)?;
+        let segment_family = try_find_uuid(r, fields, ElementId::SegmentFamily)?;
 
         if let Some(duration) = duration {
             if duration < 0.0 {
@@ -237,6 +252,13 @@ impl<R: Read + Seek> ParsableElement<R> for Info {
             title,
             muxing_app,
             writing_app,
+            segment_uuid,
+            segment_filename,
+            prev_uuid,
+            prev_filename,
+            next_uuid,
+            next_filename,
+            segment_family,
         })
     }
 }
@@ -270,6 +292,49 @@ impl Info {
     /// Writing  application.
     pub fn writing_app(&self) -> &str {
         &self.writing_app
+    }
+
+    /// A randomly generated unique ID to identify the Segment amongst many others.
+    ///
+    /// It is equivalent to a UUID v4 with all bits randomly (or pseudo-randomly) chosen.
+    pub fn segment_uuid(&self) -> Option<NonZeroU128> {
+        self.segment_uuid
+    }
+
+    /// A filename corresponding to this Segment.
+    pub fn segment_filename(&self) -> Option<&str> {
+        self.segment_filename.as_deref()
+    }
+
+    /// An ID to identify the previous Segment of a Linked Segment.
+    pub fn prev_uuid(&self) -> Option<NonZeroU128> {
+        self.prev_uuid
+    }
+
+    /// A filename corresponding to the file of the previous Linked Segment.
+    ///
+    /// Provision of the previous filename is for display convenience, but PrevUUID should be
+    /// considered authoritative for identifying the previous Segment in a Linked Segment.
+    pub fn prev_filename(&self) -> Option<&str> {
+        self.prev_filename.as_deref()
+    }
+
+    /// An ID to identify the next Segment of a Linked Segment.
+    pub fn next_uuid(&self) -> Option<NonZeroU128> {
+        self.next_uuid
+    }
+
+    /// A filename corresponding to the file of the next Linked Segment.
+    ///
+    /// Provision of the next filename is for display convenience, but PrevUUID should be considered
+    /// authoritative for identifying the next Segment in a Linked Segment.
+    pub fn next_filename(&self) -> Option<&str> {
+        self.next_filename.as_deref()
+    }
+
+    /// A unique ID that all Segments of a Linked Segment must share.
+    pub fn segment_family(&self) -> Option<NonZeroU128> {
+        self.segment_family
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1581,8 +1581,11 @@ impl Tag {
 #[derive(Clone, Debug)]
 pub struct Targets {
     target_type_value: Option<u64>,
-    _target_type: Option<String>,
+    target_type: Option<String>,
     tag_track_uid: Vec<u64>,
+    tag_edition_uid: Vec<u64>,
+    tag_chapter_uid: Vec<u64>,
+    tag_attachment_uid: Vec<u64>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for Targets {
@@ -1592,11 +1595,17 @@ impl<R: Read + Seek> ParsableElement<R> for Targets {
         let target_type_value = try_find_unsigned(fields, ElementId::TargetTypeValue)?;
         let target_type = try_find_string(fields, ElementId::TargetType)?;
         let tag_track_uid = find_all_unsigned(fields, ElementId::TagTrackUid)?;
+        let tag_edition_uid = find_all_unsigned(fields, ElementId::TagEditionUid)?;
+        let tag_chapter_uid = find_all_unsigned(fields, ElementId::TagChapterUid)?;
+        let tag_attachment_uid = find_all_unsigned(fields, ElementId::TagAttachmentUid)?;
 
         Ok(Self {
             target_type_value,
-            _target_type: target_type,
+            target_type,
             tag_track_uid,
+            tag_edition_uid,
+            tag_chapter_uid,
+            tag_attachment_uid,
         })
     }
 }
@@ -1607,10 +1616,33 @@ impl Targets {
         self.target_type_value
     }
 
+    /// The value of the tag, if it is a string.
+    pub fn target_type(&self) -> Option<&str> {
+        self.target_type.as_deref()
+    }
+
     /// A unique ID to identify the track(s) the tags belong to.
     /// If the value is 0 at this level, the tags apply to all tracks in the Segment.
     pub fn tag_track_uid(&self) -> &[u64] {
         &self.tag_track_uid
+    }
+
+    /// A unique ID to identify the edition(s) the tags belong to.
+    /// If the value is 0 at this level, the tags apply to all editions in the Segment.
+    pub fn tag_edition_uid(&self) -> &[u64] {
+        &self.tag_edition_uid
+    }
+
+    /// A unique ID to identify the chapter(s) the tags belong to.
+    /// If the value is 0 at this level, the tags apply to all chapters in the Segment.
+    pub fn tag_chapter_uid(&self) -> &[u64] {
+        &self.tag_chapter_uid
+    }
+
+    /// A unique ID to identify the attachment(s) the tags belong to.
+    /// If the value is 0 at this level, the tags apply to all attachments in the Segment.
+    pub fn tag_attachment_uid(&self) -> &[u64] {
+        &self.tag_attachment_uid
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use std::{
     convert::TryInto,
     error::Error,
     io::{Read, Seek, SeekFrom},
-    num::NonZeroU64,
+    num::{NonZeroU128, NonZeroU64},
 };
 
 use ebml::{
@@ -40,7 +40,8 @@ use ebml::{
     find_nonzero, find_nonzero_or, find_string, find_unsigned, find_unsigned_or, next_element,
     parse_children_at_offset, parse_element_header, try_find_binary, try_find_custom_type,
     try_find_custom_type_or, try_find_date, try_find_float, try_find_nonzero, try_find_string,
-    try_find_unsigned, try_parse_child, try_parse_children, ElementData, ParsableElement,
+    try_find_unsigned, try_find_uuid, try_parse_child, try_parse_children, ElementData,
+    ParsableElement,
 };
 pub use element_id::ElementId;
 pub use enums::*;
@@ -1220,6 +1221,8 @@ pub struct ChapterAtom {
     enabled: Option<bool>,
     skip_type: Option<ChapterSkipType>,
     physical_equivalent: Option<ChapterPhysicalEquiv>,
+    segment_uuid: Option<NonZeroU128>,
+    segment_edition_uid: Option<NonZeroU64>,
     displays: Vec<ChapterDisplay>,
     nested_chapters: Vec<ChapterAtom>,
     chapter_tracks: Vec<NonZeroU64>,
@@ -1248,6 +1251,9 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
         let chapter_tracks = Vec::new(); // FIXME
         let process = find_children_in_fields::<_, ChapProcess>(r, fields, ElementId::ChapProcess)?;
 
+        let segment_uuid = try_find_uuid(r, fields, ElementId::ChapterSegmentUuid)?;
+        let segment_edition_uid = try_find_nonzero(fields, ElementId::ChapterSegmentEditionUid)?;
+
         Ok(Self {
             uid,
             string_uid,
@@ -1257,6 +1263,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             enabled,
             skip_type,
             physical_equivalent,
+            segment_uuid,
+            segment_edition_uid,
             displays,
             nested_chapters,
             chapter_tracks,
@@ -1304,6 +1312,16 @@ impl ChapterAtom {
     /// Specify the physical equivalent of this ChapterAtom.
     pub fn physical_equivalent(&self) -> Option<ChapterPhysicalEquiv> {
         self.physical_equivalent
+    }
+
+    /// The SegmentUUID of another Segment to play during this chapter.
+    pub fn segment_uuid(&self) -> Option<NonZeroU128> {
+        self.segment_uuid
+    }
+
+    /// The EditionUID to play from the Segment linked in ChapterSegmentUUID.
+    pub fn segment_edition_uid(&self) -> Option<NonZeroU64> {
+        self.segment_edition_uid
     }
 
     /// Contains all possible strings to use for the chapter display.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1218,6 +1218,7 @@ pub struct ChapterAtom {
     time_end: Option<u64>,
     hidden: Option<bool>,
     enabled: Option<bool>,
+    skip_type: Option<ChapterSkipType>,
     displays: Vec<ChapterDisplay>,
     nested_chapters: Vec<ChapterAtom>,
     chapter_tracks: Vec<NonZeroU64>,
@@ -1235,6 +1236,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
         let hidden = try_find_bool(fields, ElementId::ChapterFlagHidden)?;
         let enabled = try_find_bool(fields, ElementId::ChapterFlagEnabled)?;
 
+        let skip_type = try_find_custom_type(fields, ElementId::ChapterSkipType)?;
+
         let displays =
             find_children_in_fields::<_, ChapterDisplay>(r, fields, ElementId::ChapterDisplay)?;
         let nested_chapters =
@@ -1249,6 +1252,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             time_end,
             hidden,
             enabled,
+            skip_type,
             displays,
             nested_chapters,
             chapter_tracks,
@@ -1286,6 +1290,11 @@ impl ChapterAtom {
     /// Indicate if this chapter is enabled. Defaults to `true`.
     pub fn enabled(&self) -> Option<bool> {
         self.enabled
+    }
+
+    /// Indicate what type of content the ChapterAtom contains and might be skipped.
+    pub fn skip_type(&self) -> Option<ChapterSkipType> {
+        self.skip_type
     }
 
     /// Contains all possible strings to use for the chapter display.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1651,6 +1651,7 @@ impl Targets {
 pub struct SimpleTag {
     name: String,
     language: Option<String>,
+    language_bcp47: Option<String>,
     default: Option<bool>,
     string: Option<String>,
     binary: Option<Vec<u8>>,
@@ -1663,6 +1664,7 @@ impl<R: Read + Seek> ParsableElement<R> for SimpleTag {
     fn new(r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
         let name = find_string(fields, ElementId::TagName)?;
         let language = try_find_string(fields, ElementId::TagLanguage)?;
+        let language_bcp47 = try_find_string(fields, ElementId::TagLanguageBcp47)?;
         let default = try_find_bool(fields, ElementId::TagDefault)?;
         let string = try_find_string(fields, ElementId::TagString)?;
         let binary = try_find_binary(r, fields, ElementId::TagBinary)?;
@@ -1672,6 +1674,7 @@ impl<R: Read + Seek> ParsableElement<R> for SimpleTag {
         Ok(Self {
             name,
             language,
+            language_bcp47,
             default,
             string,
             binary,
@@ -1689,6 +1692,11 @@ impl SimpleTag {
     /// Specifies the language of the tag.
     pub fn language(&self) -> Option<&str> {
         self.language.as_deref()
+    }
+
+    /// Specifies the language of the tag in the BCP47 form.
+    pub fn language_bcp47(&self) -> Option<&str> {
+        self.language_bcp47.as_deref()
     }
 
     /// Indicate if this is the default/original language to use for the given tag.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,12 @@ use std::{
 };
 
 use ebml::{
-    collect_children, expect_master, find_binary, find_bool_or, find_custom_type, find_float_or,
-    find_nonzero, find_nonzero_or, find_string, find_unsigned, find_unsigned_or, next_element,
-    parse_children_at_offset, parse_element_header, try_find_binary, try_find_custom_type,
-    try_find_custom_type_or, try_find_date, try_find_float, try_find_nonzero, try_find_string,
-    try_find_unsigned, try_find_uuid, try_parse_child, try_parse_children, ElementData,
-    ParsableElement,
+    collect_children, expect_master, find_all_unsigned, find_binary, find_bool_or,
+    find_custom_type, find_float_or, find_nonzero, find_nonzero_or, find_string, find_unsigned,
+    find_unsigned_or, next_element, parse_children_at_offset, parse_element_header,
+    try_find_binary, try_find_custom_type, try_find_custom_type_or, try_find_date, try_find_float,
+    try_find_nonzero, try_find_string, try_find_unsigned, try_find_uuid, try_parse_child,
+    try_parse_children, ElementData, ParsableElement,
 };
 pub use element_id::ElementId;
 pub use enums::*;
@@ -1582,7 +1582,7 @@ impl Tag {
 pub struct Targets {
     target_type_value: Option<u64>,
     _target_type: Option<String>,
-    tag_track_uid: Option<u64>,
+    tag_track_uid: Vec<u64>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for Targets {
@@ -1591,7 +1591,7 @@ impl<R: Read + Seek> ParsableElement<R> for Targets {
     fn new(_r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
         let target_type_value = try_find_unsigned(fields, ElementId::TargetTypeValue)?;
         let target_type = try_find_string(fields, ElementId::TargetType)?;
-        let tag_track_uid = try_find_unsigned(fields, ElementId::TagTrackUid)?;
+        let tag_track_uid = find_all_unsigned(fields, ElementId::TagTrackUid)?;
 
         Ok(Self {
             target_type_value,
@@ -1609,8 +1609,8 @@ impl Targets {
 
     /// A unique ID to identify the track(s) the tags belong to.
     /// If the value is 0 at this level, the tags apply to all tracks in the Segment.
-    pub fn tag_track_uid(&self) -> Option<u64> {
-        self.tag_track_uid
+    pub fn tag_track_uid(&self) -> &[u64] {
+        &self.tag_track_uid
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,8 @@ use std::{
 };
 
 use ebml::{
-    collect_children, expect_master, find_bool_or, find_custom_type, find_float_or, find_nonzero,
-    find_nonzero_or, find_string, find_unsigned, find_unsigned_or, next_element,
+    collect_children, expect_master, find_binary, find_bool_or, find_custom_type, find_float_or,
+    find_nonzero, find_nonzero_or, find_string, find_unsigned, find_unsigned_or, next_element,
     parse_children_at_offset, parse_element_header, try_find_binary, try_find_custom_type,
     try_find_custom_type_or, try_find_date, try_find_float, try_find_nonzero, try_find_string,
     try_find_unsigned, try_parse_child, try_parse_children, ElementData, ParsableElement,
@@ -1221,6 +1221,7 @@ pub struct ChapterAtom {
     displays: Vec<ChapterDisplay>,
     nested_chapters: Vec<ChapterAtom>,
     chapter_tracks: Vec<NonZeroU64>,
+    process: Vec<ChapProcess>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
@@ -1239,6 +1240,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
         let nested_chapters =
             find_children_in_fields::<_, ChapterAtom>(r, fields, ElementId::ChapterAtom)?;
         let chapter_tracks = Vec::new(); // FIXME
+        let process = find_children_in_fields::<_, ChapProcess>(r, fields, ElementId::ChapProcess)?;
 
         Ok(Self {
             uid,
@@ -1250,6 +1252,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             displays,
             nested_chapters,
             chapter_tracks,
+            process,
         })
     }
 }
@@ -1300,6 +1303,11 @@ impl ChapterAtom {
     pub fn chapter_tracks(&self) -> &[NonZeroU64] {
         self.chapter_tracks.as_ref()
     }
+
+    /// Contains all the commands associated to the Atom.
+    pub fn process(&self) -> &[ChapProcess] {
+        self.process.as_ref()
+    }
 }
 
 /// Contains all possible strings to use for the chapter display.
@@ -1349,6 +1357,88 @@ impl ChapterDisplay {
     /// Internet domains based on ISO3166-1 alpha-2 codes.
     pub fn country(&self) -> Option<&str> {
         self.country.as_deref()
+    }
+}
+
+/// Contains all the commands associated to the chapter atom.
+#[derive(Clone, Debug)]
+pub struct ChapProcess {
+    codec_id: ChapProcessCodecId,
+    private: Option<Vec<u8>>,
+    commands: Vec<ChapProcessCommand>,
+}
+
+impl<R: Read + Seek> ParsableElement<R> for ChapProcess {
+    type Output = Self;
+
+    fn new(r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
+        let codec_id = try_find_custom_type_or(
+            fields,
+            ElementId::ChapProcessCodecId,
+            ChapProcessCodecId::Matroska,
+        )?;
+
+        let private = try_find_binary(r, fields, ElementId::ChapProcessPrivate)?;
+
+        let commands = find_children_in_fields::<_, ChapProcessCommand>(
+            r,
+            fields,
+            ElementId::ChapProcessCommand,
+        )?;
+
+        Ok(Self {
+            codec_id,
+            private,
+            commands,
+        })
+    }
+}
+
+impl ChapProcess {
+    /// Contains the type of the codec used for the processing.
+    pub fn codec_id(&self) -> ChapProcessCodecId {
+        self.codec_id
+    }
+
+    /// Contains the command information.
+    pub fn private(&self) -> Option<&[u8]> {
+        self.private.as_deref()
+    }
+
+    /// Contains all the commands associated to the Atom.
+    pub fn commands(&self) -> &[ChapProcessCommand] {
+        self.commands.as_ref()
+    }
+}
+
+/// Contains all the commands associated to the chapter atom.
+#[derive(Clone, Debug)]
+pub struct ChapProcessCommand {
+    time: ChapProcessTime,
+    data: Vec<u8>,
+}
+
+impl<R: Read + Seek> ParsableElement<R> for ChapProcessCommand {
+    type Output = Self;
+
+    fn new(r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
+        let time = find_custom_type(fields, ElementId::ChapProcessTime)?;
+
+        let data = find_binary(r, fields, ElementId::ChapProcessData)?;
+
+        Ok(Self { time, data })
+    }
+}
+
+impl ChapProcessCommand {
+    /// Defines when the process command should be handled.
+    pub fn time(&self) -> ChapProcessTime {
+        self.time
+    }
+
+    /// Contains the command information.
+    pub fn data(&self) -> &[u8] {
+        self.data.as_ref()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1654,6 +1654,7 @@ pub struct SimpleTag {
     default: Option<bool>,
     string: Option<String>,
     binary: Option<Vec<u8>>,
+    simple_tags: Vec<SimpleTag>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for SimpleTag {
@@ -1666,12 +1667,15 @@ impl<R: Read + Seek> ParsableElement<R> for SimpleTag {
         let string = try_find_string(fields, ElementId::TagString)?;
         let binary = try_find_binary(r, fields, ElementId::TagBinary)?;
 
+        let simple_tags = find_children_in_fields::<_, SimpleTag>(r, fields, ElementId::SimpleTag)?;
+
         Ok(Self {
             name,
             language,
             default,
             string,
             binary,
+            simple_tags,
         })
     }
 }
@@ -1700,6 +1704,11 @@ impl SimpleTag {
     /// The value of the tag, if it is binary.
     pub fn binary(&self) -> Option<&[u8]> {
         self.binary.as_deref()
+    }
+
+    /// Nested tags.
+    pub fn simple_tags(&self) -> &[SimpleTag] {
+        self.simple_tags.as_slice()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1110,6 +1110,11 @@ impl ContentEncAesSettings {
 /// Contains all information about a segment edition.
 #[derive(Clone, Debug)]
 pub struct EditionEntry {
+    uid: Option<NonZeroU64>,
+    default: Option<bool>,
+    hidden: Option<bool>,
+    ordered: Option<bool>,
+    displays: Vec<EditionDisplay>,
     chapter_atoms: Vec<ChapterAtom>,
 }
 
@@ -1117,10 +1122,24 @@ impl<R: Read + Seek> ParsableElement<R> for EditionEntry {
     type Output = Self;
 
     fn new(r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
+        let uid = try_find_nonzero(fields, ElementId::EditionUid)?;
+        let default = try_find_bool(fields, ElementId::EditionFlagDefault)?;
+        let hidden = try_find_bool(fields, ElementId::EditionFlagHidden)?;
+        let ordered = try_find_bool(fields, ElementId::EditionFlagOrdered)?;
+
+        let displays =
+            find_children_in_fields::<_, EditionDisplay>(r, fields, ElementId::EditionDisplay)?;
         let chapter_atoms =
             find_children_in_fields::<_, ChapterAtom>(r, fields, ElementId::ChapterAtom)?;
 
-        Ok(Self { chapter_atoms })
+        Ok(Self {
+            uid,
+            default,
+            hidden,
+            ordered,
+            displays,
+            chapter_atoms,
+        })
     }
 }
 
@@ -1128,6 +1147,65 @@ impl EditionEntry {
     /// Contains the atom information to use as the chapter atom (apply to all tracks).
     pub fn chapter_atoms(&self) -> &[ChapterAtom] {
         self.chapter_atoms.as_ref()
+    }
+
+    /// A unique ID to identify the Edition.
+    pub fn uid(&self) -> Option<NonZeroU64> {
+        self.uid
+    }
+
+    /// Indicate if this edition should be used as the default one. Defaults to `false`.
+    pub fn default(&self) -> Option<bool> {
+        self.default
+    }
+
+    /// Indicate if this edition is hidden. Defaults to `false`.
+    pub fn hidden(&self) -> Option<bool> {
+        self.hidden
+    }
+
+    /// Indicate if the chapters can be defined multiple times and the order to play them is
+    /// enforced. Defaults to `false`.
+    pub fn ordered(&self) -> Option<bool> {
+        self.ordered
+    }
+
+    /// Contains all possible strings to use for the edition display.
+    pub fn displays(&self) -> &[EditionDisplay] {
+        self.displays.as_ref()
+    }
+}
+
+/// Contains all possible strings to use for the edition display.
+#[derive(Clone, Debug)]
+pub struct EditionDisplay {
+    string: String,
+    language_ietf: Option<String>,
+}
+
+impl<R: Read + Seek> ParsableElement<R> for EditionDisplay {
+    type Output = Self;
+
+    fn new(_r: &mut R, fields: &[(ElementId, ElementData)]) -> Result<Self> {
+        let string = find_string(fields, ElementId::EditionString)?;
+        let language_ietf = try_find_string(fields, ElementId::EditionLanguageIetf)?;
+
+        Ok(Self {
+            string,
+            language_ietf,
+        })
+    }
+}
+
+impl EditionDisplay {
+    /// Contains the string to use as the edition display.
+    pub fn string(&self) -> &str {
+        self.string.as_ref()
+    }
+
+    /// Specifies the language according to BCP47 and using the IANA Language Subtag Registry.
+    pub fn language_ietf(&self) -> Option<&str> {
+        self.language_ietf.as_deref()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1216,6 +1216,8 @@ pub struct ChapterAtom {
     string_uid: Option<String>,
     time_start: u64,
     time_end: Option<u64>,
+    hidden: Option<bool>,
+    enabled: Option<bool>,
     displays: Vec<ChapterDisplay>,
 }
 
@@ -1227,6 +1229,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
         let string_uid = try_find_string(fields, ElementId::ChapterStringUid)?;
         let time_start = find_unsigned(fields, ElementId::ChapterTimeStart)?;
         let time_end = try_find_unsigned(fields, ElementId::ChapterTimeEnd)?;
+        let hidden = try_find_bool(fields, ElementId::ChapterFlagHidden)?;
+        let enabled = try_find_bool(fields, ElementId::ChapterFlagEnabled)?;
 
         let displays =
             find_children_in_fields::<_, ChapterDisplay>(r, fields, ElementId::ChapterDisplay)?;
@@ -1236,6 +1240,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             string_uid,
             time_start,
             time_end,
+            hidden,
+            enabled,
             displays,
         })
     }
@@ -1260,6 +1266,16 @@ impl ChapterAtom {
     /// Timestamp of the end of Chapter.
     pub fn time_end(&self) -> Option<u64> {
         self.time_end
+    }
+
+    /// Indicate if this chapter is hidden. Defaults to `false`.
+    pub fn hidden(&self) -> Option<bool> {
+        self.hidden
+    }
+
+    /// Indicate if this chapter is enabled. Defaults to `true`.
+    pub fn enabled(&self) -> Option<bool> {
+        self.enabled
     }
 
     /// Contains all possible strings to use for the chapter display.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,6 +1219,7 @@ pub struct ChapterAtom {
     hidden: Option<bool>,
     enabled: Option<bool>,
     skip_type: Option<ChapterSkipType>,
+    physical_equivalent: Option<ChapterPhysicalEquiv>,
     displays: Vec<ChapterDisplay>,
     nested_chapters: Vec<ChapterAtom>,
     chapter_tracks: Vec<NonZeroU64>,
@@ -1238,6 +1239,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
 
         let skip_type = try_find_custom_type(fields, ElementId::ChapterSkipType)?;
 
+        let physical_equivalent = try_find_custom_type(fields, ElementId::ChapterPhysicalEquiv)?;
+
         let displays =
             find_children_in_fields::<_, ChapterDisplay>(r, fields, ElementId::ChapterDisplay)?;
         let nested_chapters =
@@ -1253,6 +1256,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             hidden,
             enabled,
             skip_type,
+            physical_equivalent,
             displays,
             nested_chapters,
             chapter_tracks,
@@ -1295,6 +1299,11 @@ impl ChapterAtom {
     /// Indicate what type of content the ChapterAtom contains and might be skipped.
     pub fn skip_type(&self) -> Option<ChapterSkipType> {
         self.skip_type
+    }
+
+    /// Specify the physical equivalent of this ChapterAtom.
+    pub fn physical_equivalent(&self) -> Option<ChapterPhysicalEquiv> {
+        self.physical_equivalent
     }
 
     /// Contains all possible strings to use for the chapter display.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1220,6 +1220,7 @@ pub struct ChapterAtom {
     enabled: Option<bool>,
     displays: Vec<ChapterDisplay>,
     nested_chapters: Vec<ChapterAtom>,
+    chapter_tracks: Vec<NonZeroU64>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
@@ -1237,6 +1238,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             find_children_in_fields::<_, ChapterDisplay>(r, fields, ElementId::ChapterDisplay)?;
         let nested_chapters =
             find_children_in_fields::<_, ChapterAtom>(r, fields, ElementId::ChapterAtom)?;
+        let chapter_tracks = Vec::new(); // FIXME
 
         Ok(Self {
             uid,
@@ -1247,6 +1249,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             enabled,
             displays,
             nested_chapters,
+            chapter_tracks,
         })
     }
 }
@@ -1290,6 +1293,12 @@ impl ChapterAtom {
     /// Contains all nested chapters.
     pub fn nested_chapters(&self) -> &[ChapterAtom] {
         self.nested_chapters.as_ref()
+    }
+
+    /// List of tracks on which the chapter applies.
+    /// If this Element is not present, all tracks apply.
+    pub fn chapter_tracks(&self) -> &[NonZeroU64] {
+        self.chapter_tracks.as_ref()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,6 +1219,7 @@ pub struct ChapterAtom {
     hidden: Option<bool>,
     enabled: Option<bool>,
     displays: Vec<ChapterDisplay>,
+    nested_chapters: Vec<ChapterAtom>,
 }
 
 impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
@@ -1234,6 +1235,8 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
 
         let displays =
             find_children_in_fields::<_, ChapterDisplay>(r, fields, ElementId::ChapterDisplay)?;
+        let nested_chapters =
+            find_children_in_fields::<_, ChapterAtom>(r, fields, ElementId::ChapterAtom)?;
 
         Ok(Self {
             uid,
@@ -1243,6 +1246,7 @@ impl<R: Read + Seek> ParsableElement<R> for ChapterAtom {
             hidden,
             enabled,
             displays,
+            nested_chapters,
         })
     }
 }
@@ -1281,6 +1285,11 @@ impl ChapterAtom {
     /// Contains all possible strings to use for the chapter display.
     pub fn displays(&self) -> &[ChapterDisplay] {
         self.displays.as_ref()
+    }
+
+    /// Contains all nested chapters.
+    pub fn nested_chapters(&self) -> &[ChapterAtom] {
+        self.nested_chapters.as_ref()
     }
 }
 


### PR DESCRIPTION
Lately I have been playing with multi-edition matroska videos, using ordered chapters. Brokenness all around in players and tools :laughing:.

Could all the elements that are related to this be supported?

Description of the extra elements:
- `EditionUID`: used as ID to attach a tag with the edition title to.
- `EditionFlagHidden`: the idea is that as example there is a complete file of a VHS which starts with a test signal. The edition with the test signal would be hidden, and a second edition with that part cut out and only the movie is visible.
- `EditionFlagDefault`: the default edition to play.
- `EditionFlagOrdered`: The interesting flag: whether the chapters should be understood to be order chapters.
- `EditionDisplay` with `EditionString` and `EditionLanguageIETF`: new in matroska v5, to name an edition without having to use a tag.

- `ChapterFlagHidden`: useful to hide an ordered chapter in the user interface
- `ChapterFlagEnabled`: not sure how this is supposed to behave in combination with regular and with ordered chapters.
- chapters may be nested (not my design...)
- `ChapterTrack` containing multiple `ChapterTrackUID`: not sure if this this can do anything meaningful in combination with ordered chapters...
- `ChapterSkipType`: new in matroska v5, allows tagging things like end credits.
- `ChapterPhysicalEquiv`: allows making a relation between a chapter and a physical characteristic. For example if a video came from a source that split over multiple discs. One of the idea's that give nested chapters some sense.
- `ChapterSegmentUUID` and `ChapterSegmentEditionUID`: to link to other matroska files.

- `SegmentUUID`: the info element that indentifies some other file as the target of `ChapterSegmentUUID`.
- `PrevUUID`, `NextUUID`, etc.: related methods to link files together.

- `TagEditionUID` and `TagChapterUID`: to attach tags to editions and chapters. Their value of `TITLE` takes precedence over the value set in the normal elements.
- nested tags (again not my design...)

I noticed there can be multiple `TagTrackUID`s set per tag, but currently only one is supported. By returning an slice instead this becomes a breaking change. Is that okay?

I also added parsing for `ChapProcess` and children. They are intended for the pretty much non-existing matroska menu system and quite useless. But if I write some chapter tool I want to do it properly, and that includes preserving this if present.

This PR does not do much special, but turned out quite large. Do you want it like this or differently?